### PR TITLE
max packings: fix of scoring

### DIFF
--- a/src/edu/stanford/nlp/sempre/Derivation.java
+++ b/src/edu/stanford/nlp/sempre/Derivation.java
@@ -267,7 +267,33 @@ public class Derivation implements SemanticFn.Callable, HasScore {
   public boolean isRootCat() {
     return cat.equals(Rule.rootCat);
   }
+  
+  // get the list of all categories occurring in the derivation in the depth-first order
+  public List<String> derivCategoriesDF(){
+	  List<String> allCategories = new LinkedList<String>();
+	  allCategories.add(this.getCat());
+	  for (Derivation d : this.getChildren()) {
+		  allCategories.addAll( d.derivCategoriesDF() );
+	  }
+	  return allCategories;
+  }
 
+//  public static boolean structurallyEqual(Derivation d1, Derivation d2) {
+//	  if (! d1.getCat().equals(d2.getCat())) {
+//		  return false;
+//	  }
+//	  if (d1.getChildren().size() != d2.getChildren().size()) {
+//		  return false;
+//	  }
+//	  for (int i = 0; i < d1.getChildren().size(); ++i) {
+//		  if (! structurallyEqual( d1.child(i), d2.child(i) ) ) {
+//			  return false;
+//		  }
+//	  }
+//	  return true;
+//	  
+//  }
+  
   // Functions that operate on features.
   public void addFeature(String domain, String name) { addFeature(domain, name, 1); }
   public void addFeature(String domain, String name, double value) { this.localFeatureVector.add(domain, name, value); }

--- a/src/edu/stanford/nlp/sempre/interactive/InteractiveBeamParser.java
+++ b/src/edu/stanford/nlp/sempre/interactive/InteractiveBeamParser.java
@@ -960,7 +960,10 @@ class InteractiveBeamParserState extends ChartParserState {
   private void findApplicableRules(Set<Rule> ruleSet, Map<Rule, Double> ruleSimilarityMap, Map<Rule, List<Derivation>> matchesOfRules,
 		  						List<Derivation> chartList, int start, int end) {
 	  int length = end - start;
-	  
+	  List<List<Derivation>> maximalPackings = null;
+	  if (Parser.opts.aggressivePartialParsingMode.equals("conservative")) {
+		  maximalPackings = InteractiveUtils.allMaximalPackings(chartList, numTokens);
+	  }
 	// for each action rule compute the similarity and keep the rules that are similar 
 	  for (Rule rule : ruleSet) {
 		  
@@ -968,7 +971,7 @@ class InteractiveBeamParserState extends ChartParserState {
 			  LogInfo.begin_track("Computing similarity with rule %s", rule.toString());
 		  }
 		  
-		  List<List<Derivation>> maximalPackings = null;
+		  
 		  
 		  if (Parser.opts.aggressivePartialParsingMode.equals("normal")) {
 			  //we want to filter the derivations to the categories contained in the rules,
@@ -976,10 +979,8 @@ class InteractiveBeamParserState extends ChartParserState {
 			  List<Derivation> packingMatches = ruleDerivMatchingCategories(rule, chartList);
 			  maximalPackings = InteractiveUtils.allMaximalPackings(packingMatches, numTokens);
 		  }
-		  //generate all set of maximal packings
-		  else if (Parser.opts.aggressivePartialParsingMode.equals("conservative")) {
-			  maximalPackings = InteractiveUtils.allMaximalPackings(chartList, numTokens);
-		  }
+		  
+		  
 		  
 		  if (maximalPackings != null && maximalPackings.size() > 0) {
 			  for (List<Derivation> packing : maximalPackings) {

--- a/src/edu/stanford/nlp/sempre/interactive/InteractiveBeamParser.java
+++ b/src/edu/stanford/nlp/sempre/interactive/InteractiveBeamParser.java
@@ -961,6 +961,9 @@ class InteractiveBeamParserState extends ChartParserState {
 		  						List<Derivation> chartList, int start, int end) {
 	  int length = end - start;
 	  List<List<Derivation>> maximalPackings = null;
+//	  for (Derivation dC : chartList) {
+//		  LogInfo.logs("all cats of derivation %s is %s", dC, dC.derivCategoriesDF());
+//	  }
 	  if (Parser.opts.aggressivePartialParsingMode.equals("conservative")) {
 		  maximalPackings = InteractiveUtils.allMaximalPackings(chartList, numTokens);
 	  }

--- a/src/edu/stanford/nlp/sempre/interactive/InteractiveUtils.java
+++ b/src/edu/stanford/nlp/sempre/interactive/InteractiveUtils.java
@@ -186,6 +186,7 @@ public final class InteractiveUtils {
   }
 
   
+  
   /**
    * the function that returns all maximal packings - sets of non overlapping partial derivations where adding any other partial derivation would make
    * the set overlapping.
@@ -202,6 +203,7 @@ public final class InteractiveUtils {
 		  LogInfo.logs("partialParses after filtering");
 		  for (Derivation d : partialParses){
 			  LogInfo.logs("derivation %s", d.toSimpleString());
+			  d.printDerivationRecursively();
 		  }
 	  }
 	  
@@ -215,22 +217,21 @@ public final class InteractiveUtils {
 		  f_table[i] = new ArrayList[length+1];
 	  }
 	  
-	  // if derivations are over the exactly same range, we'll keep in the interval_list only one of them (the one with the best score)
-	  // Therefore, we first sort it by score (descending) and then include only the first derivation that occurs per range
-	  Collections.sort(partialParses, new Comparator<Derivation>(){
+	  // if derivations are over the exactly same range, we'll keep in the interval_list only one of them (the one with the largest tree)
+	  // Therefore, we first sort it by the tree size (descending) and then include only the first derivation that occurs per range
+	  Collections.sort(partialParses, 
+			  new Comparator<Derivation>(){
 		  @Override
 		  public int compare(Derivation d1, Derivation d2){
-			  if (d1.getScore() > d2.getScore()){
+			  if (d1.derivCategoriesDF().size() > d2.derivCategoriesDF().size()){
 				  return -1;
-			  }
-			  else if (d1.getScore() == d2.getScore()){
-				  return 0;
-			  }
+			  }			  
 			  else {
 				  return 1;
 			  }
 		  }
-	  });
+	  }
+	  );
 
 	  
 	  


### PR DESCRIPTION
When deciding on which derivation over the same range to include, now I include the one with the biggest tree (more categories), rather than the one with the highest score.